### PR TITLE
Escape special XML characters

### DIFF
--- a/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
+++ b/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
@@ -95,6 +95,8 @@ class CommandBuilder {
     }
 
     public CommandBuilder put(String key, String value) {
+        key = escapeSpecialCharacters(key);
+        value = escapeSpecialCharacters(value);
         this.bodyEntries.put(key, value);
         return this;
     }
@@ -138,6 +140,38 @@ class CommandBuilder {
     private static HttpClient getHttpClient() {
         if(httpClient == null) { httpClient = HttpClientBuilder.create().build(); }
         return httpClient;
+    }
+
+    private String escapeSpecialCharacters(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder(value.length());
+        for(int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch(c) {
+                case '&':
+                    sb.append("&amp;");
+                    break;
+                case '<':
+                    sb.append("&lt;");
+                    break;
+                case '>':
+                    sb.append("&gt;");
+                    break;
+                case '"':
+                    sb.append("&quot;");
+                    break;
+                case '\'':
+                    sb.append("&apos;");
+                    break;
+                default:
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
     }
 
 }

--- a/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
+++ b/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
@@ -139,4 +139,5 @@ class CommandBuilder {
         if(httpClient == null) { httpClient = HttpClientBuilder.create().build(); }
         return httpClient;
     }
+
 }

--- a/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
+++ b/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
@@ -95,8 +95,6 @@ class CommandBuilder {
     }
 
     public CommandBuilder put(String key, String value) {
-        key = escapeSpecialCharacters(key);
-        value = escapeSpecialCharacters(value);
         this.bodyEntries.put(key, value);
         return this;
     }
@@ -140,37 +138,5 @@ class CommandBuilder {
     private static HttpClient getHttpClient() {
         if(httpClient == null) { httpClient = HttpClientBuilder.create().build(); }
         return httpClient;
-    }
-
-    private String escapeSpecialCharacters(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        StringBuilder sb = new StringBuilder(value.length());
-        for(int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            switch(c) {
-                case '&':
-                    sb.append("&amp;");
-                    break;
-                case '<':
-                    sb.append("&lt;");
-                    break;
-                case '>':
-                    sb.append("&gt;");
-                    break;
-                case '"':
-                    sb.append("&quot;");
-                    break;
-                case '\'':
-                    sb.append("&apos;");
-                    break;
-                default:
-                    sb.append(c);
-                    break;
-            }
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
+++ b/src/main/java/com/vmichalak/sonoscontroller/CommandBuilder.java
@@ -95,6 +95,8 @@ class CommandBuilder {
     }
 
     public CommandBuilder put(String key, String value) {
+        key = escapeSpecialCharacters(key);
+        value = escapeSpecialCharacters(value);
         this.bodyEntries.put(key, value);
         return this;
     }
@@ -140,4 +142,35 @@ class CommandBuilder {
         return httpClient;
     }
 
+    private String escapeSpecialCharacters(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder(value.length());
+        for(int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch(c) {
+                case '&':
+                    sb.append("&amp;");
+                    break;
+                case '<':
+                    sb.append("&lt;");
+                    break;
+                case '>':
+                    sb.append("&gt;");
+                    break;
+                case '"':
+                    sb.append("&quot;");
+                    break;
+                case '\'':
+                    sb.append("&apos;");
+                    break;
+                default:
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/vmichalak/sonoscontroller/SonosDevice.java
+++ b/src/main/java/com/vmichalak/sonoscontroller/SonosDevice.java
@@ -3,8 +3,6 @@ package com.vmichalak.sonoscontroller;
 import com.vmichalak.sonoscontroller.exception.SonosControllerException;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,7 +33,7 @@ public class SonosDevice {
      * @throws SonosControllerException
      */
     public void playUri(String uri, String meta) throws IOException, SonosControllerException {
-        CommandBuilder.transport("SetAVTransportURI").put("InstanceID", "0").put("CurrentURI", URLEncoder.encode(uri, StandardCharsets.UTF_8.toString()))
+        CommandBuilder.transport("SetAVTransportURI").put("InstanceID", "0").put("CurrentURI", uri)
                 .put("CurrentURIMetaData", meta).executeOn(this.ip);
         this.play();
     }

--- a/src/main/java/com/vmichalak/sonoscontroller/SonosDevice.java
+++ b/src/main/java/com/vmichalak/sonoscontroller/SonosDevice.java
@@ -3,6 +3,8 @@ package com.vmichalak.sonoscontroller;
 import com.vmichalak.sonoscontroller.exception.SonosControllerException;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,7 +35,7 @@ public class SonosDevice {
      * @throws SonosControllerException
      */
     public void playUri(String uri, String meta) throws IOException, SonosControllerException {
-        CommandBuilder.transport("SetAVTransportURI").put("InstanceID", "0").put("CurrentURI", uri)
+        CommandBuilder.transport("SetAVTransportURI").put("InstanceID", "0").put("CurrentURI", URLEncoder.encode(uri, StandardCharsets.UTF_8.toString()))
                 .put("CurrentURIMetaData", meta).executeOn(this.ip);
         this.play();
     }


### PR DESCRIPTION
While I was trying to start a playlist from Google Play Music, I noticed that it didn't work because the special characters were not escaped.
<, >, &, " and ' all have special meanings in XML and have to be represented by entities.

Example from Google Play Music:
`sonosDevice.playUri("x-sonosapi-radio:vy_wPybY9vRCoaCMySC_D6Ol9WJ1aoH97kTmNIzBZ667Frppf2koUq7ZH7OJ9bXx41s_K0RZBSA?sid=151&flags=8300&sn=3", null);`